### PR TITLE
feat(api): implement REST endpoints for order and customer queries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,12 @@
                                     @com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
                                 </additionalModelTypeAnnotations>
                             </configOptions>
+                            <typeMappings>
+                                <typeMapping>DateTime=java.time.LocalDateTime</typeMapping>
+                            </typeMappings>
+                            <importMappings>
+                                <importMapping>java.time.LocalDateTime=java.time.LocalDateTime</importMapping>
+                            </importMappings>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/main/java/com/btg/challenge/orders/app/mapper/CustomerMapper.java
+++ b/src/main/java/com/btg/challenge/orders/app/mapper/CustomerMapper.java
@@ -1,0 +1,52 @@
+package com.btg.challenge.orders.app.mapper;
+
+import com.btg.challenge.orders.domain.entity.Customer;
+import com.btg.challenge.orders.domain.entity.Order;
+import com.btg.challenge.orders.model.CustomerOrderCountResponse;
+import com.btg.challenge.orders.model.CustomerOrdersResponse;
+import com.btg.challenge.orders.model.OrderSummary;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class CustomerMapper {
+
+    private final OrderMapper orderMapper;
+
+    public CustomerOrderCountResponse toOrderCountResponse(Long customerId, long orderCount) {
+        CustomerOrderCountResponse response = new CustomerOrderCountResponse();
+        response.setCustomerId(customerId);
+        response.setOrderCount(orderCount);
+        return response;
+    }
+
+    public CustomerOrdersResponse toCustomerOrdersResponse(Page<Order> orderPage) {
+        CustomerOrdersResponse response = new CustomerOrdersResponse();
+
+        if (!orderPage.isEmpty()) {
+            response.setCustomerId(orderPage.getContent().getFirst().getCustomerId());
+
+            List<OrderSummary> orderSummaries = orderPage.getContent().stream()
+                    .map(orderMapper::toOrderSummary)
+                    .toList();
+            response.setOrders(orderSummaries);
+        }
+
+        response.setTotalElements(orderPage.getTotalElements());
+        response.setTotalPages(orderPage.getTotalPages());
+        response.setCurrentPage(orderPage.getNumber());
+        response.setPageSize(orderPage.getSize());
+
+        return response;
+    }
+
+    public CustomerOrdersResponse toCustomerOrdersResponse(Customer customer, Page<Order> orderPage) {
+        CustomerOrdersResponse response = toCustomerOrdersResponse(orderPage);
+        response.setCustomerId(customer.getCustomerId());
+        return response;
+    }
+}

--- a/src/main/java/com/btg/challenge/orders/app/mapper/OrderMapper.java
+++ b/src/main/java/com/btg/challenge/orders/app/mapper/OrderMapper.java
@@ -1,0 +1,50 @@
+package com.btg.challenge.orders.app.mapper;
+
+import com.btg.challenge.orders.domain.entity.Order;
+import com.btg.challenge.orders.domain.entity.OrderItem;
+import com.btg.challenge.orders.model.OrderItemSummary;
+import com.btg.challenge.orders.model.OrderSummary;
+import com.btg.challenge.orders.model.OrderTotalResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class OrderMapper {
+
+    public OrderTotalResponse toOrderTotalResponse(Order order) {
+        OrderTotalResponse response = new OrderTotalResponse();
+        response.setOrderId(order.getOrderId());
+        response.setTotal(order.getTotalAmount().doubleValue());
+        response.setCurrency("BRL");
+        return response;
+    }
+
+    public OrderSummary toOrderSummary(Order order) {
+        OrderSummary summary = new OrderSummary();
+        summary.setOrderId(order.getOrderId());
+        summary.setCustomerId(order.getCustomerId());
+        summary.setTotalAmount(order.getTotalAmount().doubleValue());
+        summary.setItemsCount(order.getItemsCount());
+        summary.setCreatedAt(order.getCreatedAt());
+
+        if (order.getItems() != null) {
+            List<OrderItemSummary> itemSummaries = order.getItems().stream()
+                    .map(this::toOrderItemSummary)
+                    .toList();
+            summary.setItems(itemSummaries);
+        }
+
+        return summary;
+    }
+
+    private OrderItemSummary toOrderItemSummary(OrderItem domainItem) {
+        OrderItemSummary itemSummary = new OrderItemSummary();
+        itemSummary.setProduct(domainItem.getProduct());
+        itemSummary.setQuantity(domainItem.getQuantity());
+        itemSummary.setPrice(domainItem.getPrice().doubleValue());
+        return itemSummary;
+    }
+}

--- a/src/main/java/com/btg/challenge/orders/app/resource/CustomersResource.java
+++ b/src/main/java/com/btg/challenge/orders/app/resource/CustomersResource.java
@@ -1,0 +1,62 @@
+package com.btg.challenge.orders.app.resource;
+
+import com.btg.challenge.orders.api.CustomersApiDelegate;
+import com.btg.challenge.orders.app.service.CustomerService;
+import com.btg.challenge.orders.infra.exception.CustomerNotFoundException;
+import com.btg.challenge.orders.model.CustomerOrderCountResponse;
+import com.btg.challenge.orders.model.CustomerOrdersResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.CompletableFuture;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomersResource implements CustomersApiDelegate {
+
+    private final CustomerService customerService;
+
+    @Override
+    public CompletableFuture<ResponseEntity<CustomerOrderCountResponse>> getCustomerOrderCount(Long customerId) {
+        return CompletableFuture.supplyAsync(() -> {
+            log.info("Getting order count for customerId: {}", customerId);
+
+            try {
+                CustomerOrderCountResponse response = customerService.getOrderCount(customerId);
+                return ResponseEntity.ok(response);
+            } catch (CustomerNotFoundException e) {
+                log.error("Customer not found: {}", customerId);
+                return ResponseEntity.notFound().build();
+            } catch (Exception e) {
+                log.error("Error getting order count for customerId: {}", customerId, e);
+                return ResponseEntity.internalServerError().build();
+            }
+        });
+    }
+
+    @Override
+    public CompletableFuture<ResponseEntity<CustomerOrdersResponse>> getCustomerOrders(
+            Long customerId,
+            Integer page,
+            Integer size,
+            Pageable pageable) {
+        return CompletableFuture.supplyAsync(() -> {
+            log.info("Getting orders for customerId: {}, pageable: {}", customerId, pageable);
+
+            try {
+                CustomerOrdersResponse response = customerService.getCustomerOrders(customerId, pageable);
+                return ResponseEntity.ok(response);
+            } catch (CustomerNotFoundException e) {
+                log.error("Customer not found: {}", customerId);
+                return ResponseEntity.notFound().build();
+            } catch (Exception e) {
+                log.error("Error getting orders for customerId: {}", customerId, e);
+                return ResponseEntity.internalServerError().build();
+            }
+        });
+    }
+}

--- a/src/main/java/com/btg/challenge/orders/app/resource/HealthResource.java
+++ b/src/main/java/com/btg/challenge/orders/app/resource/HealthResource.java
@@ -1,0 +1,26 @@
+package com.btg.challenge.orders.app.resource;
+
+import com.btg.challenge.orders.api.HealthApiDelegate;
+import com.btg.challenge.orders.model.HealthResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.CompletableFuture;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class HealthResource implements HealthApiDelegate {
+
+    @Override
+    public CompletableFuture<ResponseEntity<HealthResponse>> healthCheck() {
+        return CompletableFuture.supplyAsync(() -> {
+            log.debug("Performing health check");
+            HealthResponse healthResponse = new HealthResponse();
+            healthResponse.setStatus("UP");
+            return ResponseEntity.ok(healthResponse);
+        });
+    }
+}

--- a/src/main/java/com/btg/challenge/orders/app/resource/OrdersResource.java
+++ b/src/main/java/com/btg/challenge/orders/app/resource/OrdersResource.java
@@ -1,0 +1,36 @@
+package com.btg.challenge.orders.app.resource;
+
+import com.btg.challenge.orders.api.OrdersApiDelegate;
+import com.btg.challenge.orders.app.service.OrderService;
+import com.btg.challenge.orders.infra.exception.OrderNotFoundException;
+import com.btg.challenge.orders.model.OrderTotalResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.CompletableFuture;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OrdersResource implements OrdersApiDelegate {
+
+    private final OrderService orderService;
+
+    @Override
+    public CompletableFuture<ResponseEntity<OrderTotalResponse>> getOrderTotal(Long orderId) {
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                OrderTotalResponse response = orderService.getOrderTotal(orderId);
+                return ResponseEntity.ok(response);
+            } catch (OrderNotFoundException e) {
+                log.error("Order not found: {}", orderId);
+                return ResponseEntity.notFound().build();
+            } catch (Exception e) {
+                log.error("Error getting order total for orderId: {}", orderId, e);
+                return ResponseEntity.internalServerError().build();
+            }
+        });
+    }
+}

--- a/src/main/java/com/btg/challenge/orders/app/service/CustomerService.java
+++ b/src/main/java/com/btg/challenge/orders/app/service/CustomerService.java
@@ -1,0 +1,12 @@
+package com.btg.challenge.orders.app.service;
+
+import com.btg.challenge.orders.model.CustomerOrderCountResponse;
+import com.btg.challenge.orders.model.CustomerOrdersResponse;
+import org.springframework.data.domain.Pageable;
+
+public interface CustomerService {
+
+    CustomerOrderCountResponse getOrderCount(Long customerId);
+
+    CustomerOrdersResponse getCustomerOrders(Long customerId, Pageable pageable);
+}

--- a/src/main/java/com/btg/challenge/orders/app/service/OrderMessagingService.java
+++ b/src/main/java/com/btg/challenge/orders/app/service/OrderMessagingService.java
@@ -1,34 +1,7 @@
 package com.btg.challenge.orders.app.service;
 
-import com.btg.challenge.orders.domain.entity.Order;
-import com.btg.challenge.orders.domain.usecase.ProcessOrderUseCase;
 import com.btg.challenge.orders.infra.mqprovider.OrderMessage;
-import com.btg.challenge.orders.app.mapper.OrderMessageMapper;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-@Slf4j
-@Service
-@RequiredArgsConstructor
-public class OrderMessagingService {
-
-    private final ProcessOrderUseCase processOrderUseCase;
-    private final OrderMessageMapper orderMessageMapper;
-
-    @Transactional
-    public void processOrderMessage(OrderMessage orderMessage) {
-        log.info("Processing order message: orderId={}, customerId={}",
-                orderMessage.getCodigoPedido(), orderMessage.getCodigoCliente());
-
-        try {
-            Order order = orderMessageMapper.toDomain(orderMessage);
-            processOrderUseCase.execute(order);
-        } catch (Exception e) {
-            log.error("Error processing order message: orderId={}, error={}",
-                    orderMessage.getCodigoPedido(), e.getMessage(), e);
-            throw e;
-        }
-    }
+public interface OrderMessagingService {
+    void processOrderMessage(OrderMessage orderMessage);
 }

--- a/src/main/java/com/btg/challenge/orders/app/service/OrderService.java
+++ b/src/main/java/com/btg/challenge/orders/app/service/OrderService.java
@@ -1,0 +1,7 @@
+package com.btg.challenge.orders.app.service;
+
+import com.btg.challenge.orders.model.OrderTotalResponse;
+
+public interface OrderService {
+    OrderTotalResponse getOrderTotal(Long orderId);
+}

--- a/src/main/java/com/btg/challenge/orders/app/service/impl/CustomerServiceImpl.java
+++ b/src/main/java/com/btg/challenge/orders/app/service/impl/CustomerServiceImpl.java
@@ -1,0 +1,32 @@
+package com.btg.challenge.orders.app.service.impl;
+
+import com.btg.challenge.orders.app.mapper.CustomerMapper;
+import com.btg.challenge.orders.app.service.CustomerService;
+import com.btg.challenge.orders.domain.usecase.GetCustomerOrderCountUseCase;
+import com.btg.challenge.orders.domain.usecase.GetCustomerOrdersUseCase;
+import com.btg.challenge.orders.model.CustomerOrderCountResponse;
+import com.btg.challenge.orders.model.CustomerOrdersResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomerServiceImpl implements CustomerService {
+
+    private final GetCustomerOrderCountUseCase getOrderCountUseCase;
+    private final GetCustomerOrdersUseCase getCustomerOrdersUseCase;
+    private final CustomerMapper customerMapper;
+
+    @Override
+    public CustomerOrderCountResponse getOrderCount(Long customerId) {
+        var orderCount = getOrderCountUseCase.execute(customerId);
+        return customerMapper.toOrderCountResponse(customerId, orderCount);
+    }
+
+    @Override
+    public CustomerOrdersResponse getCustomerOrders(Long customerId, Pageable pageable) {
+        var customerOrdersPage = getCustomerOrdersUseCase.execute(customerId, pageable);
+        return customerMapper.toCustomerOrdersResponse(customerOrdersPage);
+    }
+}

--- a/src/main/java/com/btg/challenge/orders/app/service/impl/OrderMessagingServiceImpl.java
+++ b/src/main/java/com/btg/challenge/orders/app/service/impl/OrderMessagingServiceImpl.java
@@ -1,0 +1,36 @@
+package com.btg.challenge.orders.app.service.impl;
+
+import com.btg.challenge.orders.app.service.OrderMessagingService;
+import com.btg.challenge.orders.domain.entity.Order;
+import com.btg.challenge.orders.domain.usecase.ProcessOrderUseCase;
+import com.btg.challenge.orders.infra.mqprovider.OrderMessage;
+import com.btg.challenge.orders.app.mapper.OrderMessageMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OrderMessagingServiceImpl implements OrderMessagingService {
+
+    private final ProcessOrderUseCase processOrderUseCase;
+    private final OrderMessageMapper orderMessageMapper;
+
+    @Override
+    @Transactional
+    public void processOrderMessage(OrderMessage orderMessage) {
+        log.info("Processing order message: orderId={}, customerId={}",
+                orderMessage.getCodigoPedido(), orderMessage.getCodigoCliente());
+
+        try {
+            Order order = orderMessageMapper.toDomain(orderMessage);
+            processOrderUseCase.execute(order);
+        } catch (Exception e) {
+            log.error("Error processing order message: orderId={}, error={}",
+                    orderMessage.getCodigoPedido(), e.getMessage(), e);
+            throw e;
+        }
+    }
+}

--- a/src/main/java/com/btg/challenge/orders/app/service/impl/OrderServiceImpl.java
+++ b/src/main/java/com/btg/challenge/orders/app/service/impl/OrderServiceImpl.java
@@ -1,0 +1,25 @@
+package com.btg.challenge.orders.app.service.impl;
+
+import com.btg.challenge.orders.app.mapper.OrderMapper;
+import com.btg.challenge.orders.app.service.OrderService;
+import com.btg.challenge.orders.domain.usecase.GetOrderTotalUseCase;
+import com.btg.challenge.orders.infra.exception.OrderNotFoundException;
+import com.btg.challenge.orders.model.OrderTotalResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OrderServiceImpl implements OrderService {
+
+    private final GetOrderTotalUseCase getOrderTotalUseCase;
+    private final OrderMapper orderResponseMapper;
+
+    @Override
+    public OrderTotalResponse getOrderTotal(Long orderId) {
+        var orderTotal = getOrderTotalUseCase.execute(orderId)
+                .orElseThrow(() -> new OrderNotFoundException(orderId));
+
+        return orderResponseMapper.toOrderTotalResponse(orderTotal);
+    }
+}

--- a/src/main/java/com/btg/challenge/orders/domain/usecase/GetCustomerOrderCountUseCase.java
+++ b/src/main/java/com/btg/challenge/orders/domain/usecase/GetCustomerOrderCountUseCase.java
@@ -1,0 +1,29 @@
+package com.btg.challenge.orders.domain.usecase;
+
+import com.btg.challenge.orders.domain.CustomerDataProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GetCustomerOrderCountUseCase {
+
+    private final CustomerDataProvider customerDataProvider;
+
+    public long execute(Long customerId) {
+        log.info("Getting order count for customerId: {}", customerId);
+
+        if (customerId == null || customerId <= 0) {
+            log.warn("Invalid customerId provided: {}", customerId);
+            return 0L;
+        }
+
+        long orderCount = customerDataProvider.countOrdersByCustomerId(customerId);
+
+        log.info("Order count for customerId {}: {}", customerId, orderCount);
+
+        return orderCount;
+    }
+}

--- a/src/main/java/com/btg/challenge/orders/domain/usecase/GetCustomerOrdersUseCase.java
+++ b/src/main/java/com/btg/challenge/orders/domain/usecase/GetCustomerOrdersUseCase.java
@@ -1,0 +1,57 @@
+package com.btg.challenge.orders.domain.usecase;
+
+import com.btg.challenge.orders.domain.CustomerDataProvider;
+import com.btg.challenge.orders.domain.OrderDataProvider;
+import com.btg.challenge.orders.domain.entity.Order;
+import com.btg.challenge.orders.infra.exception.CustomerNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GetCustomerOrdersUseCase {
+
+    private final OrderDataProvider orderDataProvider;
+    private final CustomerDataProvider customerDataProvider;
+
+    @Transactional(readOnly = true)
+    public Page<Order> execute(Long customerId, Pageable pageable) {
+        log.info("Getting orders for customerId: {}, pageable: {}", customerId, pageable);
+
+        if (customerId == null || customerId <= 0) {
+            log.warn("Invalid customerId provided: {}", customerId);
+            throw new CustomerNotFoundException("Invalid customer ID: " + customerId);
+        }
+
+        if (!customerExists(customerId)) {
+            log.warn("Customer not found with id: {}", customerId);
+            throw new CustomerNotFoundException(customerId);
+        }
+
+        Pageable pageableWithSort = addDefaultSorting(pageable);
+
+        Page<Order> ordersPage = orderDataProvider.findByCustomerId(customerId, pageableWithSort);
+
+        log.info("Found {} orders for customerId: {} (page {}/{})", ordersPage.getNumberOfElements(), customerId, ordersPage.getNumber() + 1, ordersPage.getTotalPages());
+
+        return ordersPage;
+    }
+
+    private Pageable addDefaultSorting(Pageable pageable) {
+        if (pageable.getSort().isUnsorted()) {
+            return PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), Sort.by("createdAt").descending());
+        }
+        return pageable;
+    }
+
+    private boolean customerExists(Long customerId) {
+        return customerDataProvider.findById(customerId).isPresent();
+    }
+}

--- a/src/main/java/com/btg/challenge/orders/domain/usecase/GetOrderTotalUseCase.java
+++ b/src/main/java/com/btg/challenge/orders/domain/usecase/GetOrderTotalUseCase.java
@@ -1,0 +1,42 @@
+package com.btg.challenge.orders.domain.usecase;
+
+import com.btg.challenge.orders.domain.OrderDataProvider;
+import com.btg.challenge.orders.domain.entity.Order;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GetOrderTotalUseCase {
+
+    private final OrderDataProvider orderDataProvider;
+
+    public Optional<Order> execute(Long orderId) {
+        log.info("Getting order total for orderId: {}", orderId);
+
+        if (orderId == null || orderId <= 0) {
+            log.warn("Invalid orderId provided: {}", orderId);
+            return Optional.empty();
+        }
+
+        Optional<Order> orderOptional = orderDataProvider.findByIdWithItems(orderId);
+
+        if (orderOptional.isEmpty()) {
+            log.warn("Order not found with id: {}", orderId);
+            return Optional.empty();
+        }
+
+        Order order = orderOptional.get();
+
+        order.updateTotals();
+
+        log.info("Order found - orderId: {}, total: {}, itemsCount: {}",
+                orderId, order.getTotalAmount(), order.getItemsCount());
+
+        return Optional.of(order);
+    }
+}

--- a/src/main/java/com/btg/challenge/orders/infra/exception/CustomerNotFoundException.java
+++ b/src/main/java/com/btg/challenge/orders/infra/exception/CustomerNotFoundException.java
@@ -1,0 +1,11 @@
+package com.btg.challenge.orders.infra.exception;
+
+public class CustomerNotFoundException extends RuntimeException {
+    public CustomerNotFoundException(String message) {
+        super(message);
+    }
+
+    public CustomerNotFoundException(Long customerId) {
+        super("Customer not found with id: " + customerId);
+    }
+}

--- a/src/main/java/com/btg/challenge/orders/infra/exception/OrderNotFoundException.java
+++ b/src/main/java/com/btg/challenge/orders/infra/exception/OrderNotFoundException.java
@@ -1,0 +1,11 @@
+package com.btg.challenge.orders.infra.exception;
+
+public class OrderNotFoundException extends RuntimeException {
+    public OrderNotFoundException(String message) {
+        super(message);
+    }
+
+    public OrderNotFoundException(Long orderId) {
+        super("Order not found with id: " + orderId);
+    }
+}

--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -112,6 +112,7 @@ paths:
           description: Page number (starting from 0)
           schema:
             type: integer
+            format: int32
             minimum: 0
             default: 0
             example: 0
@@ -144,6 +145,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+      x-spring-paginated: true
 
   /actuator/health:
     get:
@@ -158,21 +160,17 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  status:
-                    type: string
-                    example: UP
+                $ref: '#/components/schemas/HealthResponse'
 
 components:
   schemas:
     OrderTotalResponse:
       type: object
       required:
-        - order_id
+        - orderId
         - total
       properties:
-        order_id:
+        orderId:
           type: integer
           format: int64
           description: Order ID
@@ -191,10 +189,10 @@ components:
     CustomerOrderCountResponse:
       type: object
       required:
-        - customer_id
+        - customerId
         - orderCount
       properties:
-        customer_id:
+        customerId:
           type: integer
           format: int64
           description: Customer ID
@@ -208,13 +206,13 @@ components:
     CustomerOrdersResponse:
       type: object
       required:
-        - customer_id
+        - customerId
         - orders
         - totalElements
         - totalPages
         - currentPage
       properties:
-        customer_id:
+        customerId:
           type: integer
           format: int64
           description: Customer ID
@@ -245,18 +243,18 @@ components:
     OrderSummary:
       type: object
       required:
-        - order_id
-        - customer_id
+        - orderId
+        - customerId
         - totalAmount
         - itemsCount
         - createdAt
       properties:
-        order_id:
+        orderId:
           type: integer
           format: int64
           description: Order ID
           example: 1001
-        customer_id:
+        customerId:
           type: integer
           format: int64
           description: Customer ID
@@ -278,10 +276,10 @@ components:
         items:
           type: array
           items:
-            $ref: '#/components/schemas/OrderItem'
+            $ref: '#/components/schemas/OrderItemSummary'
           description: Order items
 
-    OrderItem:
+    OrderItemSummary:
       type: object
       required:
         - product
@@ -304,6 +302,15 @@ components:
           description: Product unit price
           minimum: 0
           example: 1.10
+
+    HealthResponse:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          type: string
+          example: UP
 
     ErrorResponse:
       type: object


### PR DESCRIPTION
- Add OrdersResource and CustomersResource implementing OpenAPI delegates
- Create GetOrderTotalUseCase, GetCustomerOrderCountUseCase, GetCustomerOrdersUseCase
- Implement OrderMapper and CustomerMapper for domain to API model conversion
- Add OrderService and CustomerService with business logic orchestration
- Support paginated customer orders with Pageable integration and default sorting
- Include HealthResource with proper HealthResponse model
- Add proper exception handling with CustomerNotFoundException and OrderNotFoundException
- Apply @Transactional(readOnly = true) for lazy loading support
- Include structured logging across all components

Endpoints implemented:
- GET /api/v1/orders/{order_id}/total
- GET /api/v1/customers/{customer_id}/orders/count
- GET /api/v1/customers/{customer_id}/orders (with pagination)
- GET /actuator/health

Tasks: T4.1, T4.2, T4.3, T4.4 - REST API implementation complete